### PR TITLE
Enhancement for iTerm profiles

### DIFF
--- a/MenuBarSSHCommands/MenuBarSSHCommandsApp.swift
+++ b/MenuBarSSHCommands/MenuBarSSHCommandsApp.swift
@@ -14,9 +14,9 @@ class ButtonContainerStore: ObservableObject {
     @Published var buttonContainer: [ButtonContainer] = []
     let jsonFileName = "MenuBarSSHCommandsData"
     var terminal: String = "Terminal"
-    
+
     private var fileMonitor: FileMonitor?
-    
+
     init() {
         do {
             loadButtonContainer()
@@ -44,7 +44,7 @@ class ButtonContainerStore: ObservableObject {
             }
         }
     }
-    
+
     private func startMonitoringFileChanges() {
             let fileURL = Bundle.main.url(forResource: jsonFileName, withExtension: "json")
             fileMonitor = FileMonitor(fileURL: fileURL)
@@ -100,7 +100,7 @@ class FileMonitor {
 
 @main
 struct MenuBarSSHCommandsApp: App {
-    
+
     @StateObject private var buttonContainerStore = ButtonContainerStore()
     var body: some Scene {
         MenuBarExtra{
@@ -131,14 +131,14 @@ struct MenuBarSSHCommandsApp: App {
            })
         }
         label: {
-        
+
             let image: NSImage = {
                 let ratio = $0.size.height / $0.size.width
                 $0.size.height = 18
                 $0.size.width = 18 / ratio
                 return $0
             }(NSImage(named: "Icon")!)
-        
+
             Image(nsImage: image)
         }
     }
@@ -146,7 +146,7 @@ struct MenuBarSSHCommandsApp: App {
     private func executeCommand(_ command: String) {
         let terminal = buttonContainerStore.terminal
         var source: String
-        var profile: String = "Default"
+        var profile: String = "default profile"
 
         let modifiedCommand = removeProfileParameter(from: command, profile: &profile)
 
@@ -155,7 +155,7 @@ struct MenuBarSSHCommandsApp: App {
             if application "\(terminal)" is running then
                 tell application "\(terminal)"
                     activate
-                    tell (create window with profile "\(profile)")
+                    tell (create window with \(profile))
                         delay 0.2 -- Wait for the terminal to launch
                         tell current session
                             write text "\(modifiedCommand)"
@@ -213,12 +213,12 @@ struct MenuBarSSHCommandsApp: App {
     }
 
 
-    
+
     private func openJSONFile() {
         guard let url = Bundle.main.url(forResource: buttonContainerStore.jsonFileName, withExtension: "json") else {
             return
         }
-        
+
         NSWorkspace.shared.open(url)
     }
 
@@ -229,7 +229,7 @@ struct MenuBarSSHCommandsApp: App {
         if let index = components.firstIndex(of: "--profile".split(separator: " ")[0]) {
             if index + 1 < components.count {
                 let profileValue = components[index + 1]
-                profile = profileValue.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                profile = "profile \"\(profileValue.trimmingCharacters(in: CharacterSet(charactersIn: "\"")) )\""
 
                 modifiedCommand = components.enumerated().compactMap { (i, element) in
                     if i == index || i == index + 1 {

--- a/MenuBarSSHCommands/MenuBarSSHCommandsApp.swift
+++ b/MenuBarSSHCommands/MenuBarSSHCommandsApp.swift
@@ -146,15 +146,19 @@ struct MenuBarSSHCommandsApp: App {
     private func executeCommand(_ command: String) {
         let terminal = buttonContainerStore.terminal
         var source: String
+        var profile: String = "Default"
+
+        let modifiedCommand = removeProfileParameter(from: command, profile: &profile)
+
         if terminal == "iTerm" {
             source = """
             if application "\(terminal)" is running then
                 tell application "\(terminal)"
                     activate
-                    tell (create window with default profile)
+                    tell (create window with profile "\(profile)")
                         delay 0.2 -- Wait for the terminal to launch
                         tell current session
-                            write text "\(command)"
+                            write text "\(modifiedCommand)"
                         end tell
                     end tell
                 end tell
@@ -164,7 +168,7 @@ struct MenuBarSSHCommandsApp: App {
                     delay 0.5 -- Wait for the terminal to launch
                     tell current window
                         tell current session
-                            write text "\(command)"
+                            write text "\(modifiedCommand)"
                         end tell
                     end tell
                 end tell
@@ -175,16 +179,16 @@ struct MenuBarSSHCommandsApp: App {
             if application "\(terminal)" is not running then
                 tell application "\(terminal)"
                     activate
-                    do script "\(command)"
+                    do script "\(modifiedCommand)"
                 end tell
             else
                 tell application "\(terminal)"
                     if (count windows) > 0 then
                         tell front window
-                            do script "\(command)"
+                            do script "\(modifiedCommand)"
                         end tell
                     else
-                        do script "\(command)"
+                        do script "\(modifiedCommand)"
                     end if
                     activate
                 end tell
@@ -216,6 +220,27 @@ struct MenuBarSSHCommandsApp: App {
         }
         
         NSWorkspace.shared.open(url)
+    }
+
+    private func removeProfileParameter(from command: String, profile: inout String) -> String {
+        var modifiedCommand = command
+        let components = command.split(separator: " ")
+
+        if let index = components.firstIndex(of: "--profile".split(separator: " ")[0]) {
+            if index + 1 < components.count {
+                let profileValue = components[index + 1]
+                profile = profileValue.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+
+                modifiedCommand = components.enumerated().compactMap { (i, element) in
+                    if i == index || i == index + 1 {
+                        return nil // Skip the --profile and its value
+                    }
+                    return String(element)
+                }.joined(separator: " ")
+            }
+        }
+
+        return modifiedCommand
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ A simple Terminal and SSH Command Shortcut Menu Bar App for built for MacOS Vent
 
 <a href="https://www.buymeacoffee.com/dieskim" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
+#### iTerm Profile Integration
+
+When using iTerm, you can specify which profile to use by adding the `--profile` flag to your SSH command. This is helpful if you maintain different profiles for various environments (like production, staging, etc.).
+
+For example, if you have an iTerm profile named "Production" configured with specific settings for production servers, you can reference it in your configuration like this:
+
+```json
+{
+  "terminal": "iTerm",  // Supported terminals: 'Terminal' or 'iTerm' (recommended)
+  "data": [
+    {
+      "action": [
+        {
+          "name": "Action1",
+          "command": "ssh admin@host.com --profile Production"
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## Credits
 
 MenuBarSSHCommands was inspired by [Shuttle](https://github.com/fitztrev/shuttle) and [SSHMenu](http://sshmenu.sourceforge.net/), the GNOME applet for Linux.


### PR DESCRIPTION
First off, thank you for the nice simple productivity tool. I have found this tool to be useful in my day to day workflow.

I have proposed an enhancement for iTerm that will allow you to specify the iTerm profile you would like to use. 

For example, if you have an iTerm profile named "Production" configured with specific settings for production servers, you can open the iTerm with that profile by passing the `--profile` flag with the profile name as the following value.

I have provided some more details in the README.md

I hope you find this enhancement as useful as I have and will consider merging.